### PR TITLE
Allow cpm to run without a terminal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+**/*.o
+cpm
+cpmtool
+nbproject/*

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,12 @@
 # -DMEM_BREAK		support memory-mapped I/O and breakpoints,
 #				which will noticably slow down emulation
 
+ifeq ($(OS),Windows_NT)
+  EXE 		:= .exe
+else
+  EXE 		:=
+endif
+
 CC = gcc
 CFLAGS = -g -pipe -Wall -DPOSIX_TTY -DLITTLE_ENDIAN -DMEM_BREAK
 LDFLAGS = 
@@ -21,13 +27,13 @@ OBJS =	bios.o \
 	bdos.o \
 	z80.o
 
-all: cpm cpmtool
+all: cpm$(EXE) cpmtool$(EXE)
 
-cpmtool: cpmtool.o
-	$(CC) $(CFLAGS) $(LDFLAGS) -o cpmtool cpmtool.o
+cpmtool$(EXE): cpmtool.o
+	$(CC) $(CFLAGS) $(LDFLAGS) -o cpmtool$(EXE) cpmtool.o
 
-cpm: $(OBJS)
-	$(CC) $(CFLAGS) $(LDFLAGS) -o cpm $(OBJS)
+cpm$(EXE): $(OBJS)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o cpm$(EXE) $(OBJS)
 
 
 bios.o:		bios.c defs.h cpmdisc.h cpm.c
@@ -36,7 +42,7 @@ disassem.o:	disassem.c defs.h
 main.o:		main.c defs.h
 
 clean:
-	rm -f cpm cpmtool *.o *~
+	rm -f cpm$(EXE) cpmtool$(EXE) *.o *~
 
 tags:	$(FILES)
 	cxxtags *.[hc]

--- a/main.c
+++ b/main.c
@@ -54,6 +54,7 @@ static FILE *logfile = NULL;
 #endif
 static struct termio rawterm, oldterm;	/* for raw terminal I/O */
 #endif
+static int have_term = 1;   /* FALSE if terminal initialization failed */
 
 
 static void dumptrace(z80info *z80);
@@ -78,6 +79,7 @@ char *jgets(char *s, int len, FILE *f)
 void
 resetterm(void)
 {
+    if (have_term)
 	tcsetattr(fileno(stdin), TCSADRAIN, &oldterm);
 }
 
@@ -90,6 +92,7 @@ resetterm(void)
 void
 setterm(void)
 {
+    if (have_term)
 	tcsetattr(fileno(stdin), TCSADRAIN, &rawterm);
 }
 
@@ -105,9 +108,10 @@ initterm(void)
 {
 	if (tcgetattr(fileno(stdin), &oldterm))
 	{
-		fprintf(stderr, "Sorry, Must be using a terminal.\n");
-		exit(1);
+		fprintf(stderr, "Sorry, terminal not found, using cooked mode.\n");
+		have_term = 0;
 	}
+        else {
 	rawterm = oldterm;
 	rawterm.c_iflag &= ~(ICRNL | IXON | IXOFF | INLCR | ICRNL);
 	rawterm.c_lflag &= ~(ICANON | ECHO);

--- a/main.c
+++ b/main.c
@@ -119,7 +119,7 @@ initterm(void)
 	rawterm.c_cc[VQUIT] = -1;
 	rawterm.c_cc[VERASE] = -1;
 	rawterm.c_cc[VKILL] = -1;
-
+	}
 	// tcsetattr(fileno(stdin), TCSADRAIN, &rawterm);
 
 #if 0
@@ -268,7 +268,7 @@ loop:	/* "infinite" loop */
 		}
 
 		break;
-	
+
 	case 'w':			/* write memory to file */
 		printf("    Starting at loc? ");
 		jgets(str, sizeof(str), stdin);
@@ -416,7 +416,7 @@ loop:	/* "infinite" loop */
 			po++;
 		}
 		break;
-			
+
 	case 'r':				/* set a register */
 		printf("    Value? = ");
 		jgets(str, sizeof(str), stdin);
@@ -438,7 +438,7 @@ loop:	/* "infinite" loop */
 		case 'e': E = i; break;
 		case 'h': H = i; break;
 		case 'l': L = i; break;
-		case 'i': 
+		case 'i':
 			if (tolower(((unsigned char *)s)[1]) == 'x')
 				IX = i;
 			else if (tolower(((unsigned char *)s)[1]) == 'y')
@@ -751,7 +751,7 @@ input(z80info *z80, byte haddr, byte laddr, byte *val)
 		{
 #if defined macintosh
 			EventRecord ev;
-			
+
 		again:
 			fflush(stdout);
 
@@ -798,7 +798,7 @@ input(z80info *z80, byte haddr, byte laddr, byte *val)
 
 	/* return 0xFF if we have a character waiting to be read - save the
 	   character in "last" for 0x00 above */
-	case 0x01: 
+	case 0x01:
 #if defined macintosh
 		{
 			EventRecord ev;
@@ -841,8 +841,8 @@ void
 output(z80info *z80, byte haddr, byte laddr, byte data)
 {
 	if (laddr == 0xFF) {
-		/* BIOS call - interrupt the z80 before the next instruction 
-		   since we may have to mess with the PC & other stuff - 
+		/* BIOS call - interrupt the z80 before the next instruction
+		   since we may have to mess with the PC & other stuff -
 		   otherwise we would do it right here */
 		z80->event = TRUE;
 		z80->halt = TRUE;
@@ -881,7 +881,7 @@ void
 haltcpu(z80info *z80)
 {
 	z80->halt = FALSE;
-	
+
 	/* we were interrupted by a Unix signal */
 	if (z80->sig)
 	{
@@ -1020,7 +1020,7 @@ interrupt(int s)
 
 
 /*-----------------------------------------------------------------------*\
- |  main  --  set up the global vars & run the z80 
+ |  main  --  set up the global vars & run the z80
 \*-----------------------------------------------------------------------*/
 
 int

--- a/vt.c
+++ b/vt.c
@@ -17,15 +17,19 @@ int kpoll(int w)
 		return c;
 	}
 	for (tries = 0; tries != 1; ++tries) {
+#ifndef _WIN32
 		int flags;
 		if (w) {
 			flags = fcntl(fileno(stdin), F_GETFL);
 			fcntl(fileno(stdin), F_SETFL, flags | O_NONBLOCK);
 		}
+#endif
 		c = read(fileno(stdin), &d, 1);
+#ifndef _WIN32
 		if (w) {
 			fcntl(fileno(stdin), F_SETFL, flags);
 		}
+#endif
 		if (c == 1) {
 /*			printf("\r\nkpoll got %d \r\n", d); */
 			return d;


### PR DESCRIPTION
I use cpm to test the output of cpm cross-compilation and need it to be able to read standard input and
write to standard output.
This patch allows that.