### PR TITLE
Compile with ANSI options and fix compiler warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,9 @@
 #				which will noticably slow down emulation
 
 CC = gcc
-CFLAGS = -g -pipe -Wall -DPOSIX_TTY -DLITTLE_ENDIAN -DMEM_BREAK
+CFLAGS = -g -pipe -Wall -Wextra -pedantic -ansi \
+	 -D_POSIX_C_SOURCE=200809L -DPOSIX_TTY \
+	 -DLITTLE_ENDIAN -DMEM_BREAK
 LDFLAGS = 
 
 FILES = README.md Makefile A-Hdrive B-Hdrive cpmws.png \

--- a/bdos.c
+++ b/bdos.c
@@ -171,7 +171,7 @@ static void storefp(z80info *z80, FILE *fp, unsigned where) {
     stfps[ind].name[11] = '\0';
 }
 
-// Lookup an FCB to find the host file.
+/* Lookup an FCB to find the host file. */
 
 static FILE *lookfp(z80info *z80, unsigned where) {
     int i;
@@ -189,7 +189,7 @@ static FILE *lookfp(z80info *z80, unsigned where) {
     return NULL;
 }
 
-// Report an error finding an FCB.
+/* Report an error finding an FCB. */
 
 static void fcberr(z80info *z80, unsigned where) {
     int i;
@@ -204,7 +204,7 @@ static void fcberr(z80info *z80, unsigned where) {
     exit(1);
 }
 
-// Get the host file for an FCB when it should be open.
+/* Get the host file for an FCB when it should be open. */
 
 static FILE *getfp(z80info *z80, unsigned where) {
     FILE *fp;
@@ -330,20 +330,20 @@ char *bdos_decode(int n)
 int bdos_fcb(int n)
 {
 	switch (n) {
-	    case 15: return 1; // "open file";
-	    case 16: return 1; // "close file";
-	    case 17: return 1; // "search for first";
-	    case 18: return 1; // "search for next";
-	    case 19: return 1; // "delete file (no wildcards yet)";
-	    case 20: return 1; // "read sequential";
-	    case 21: return 1; // "write sequential";
-	    case 22: return 1; // "make file";
-	    case 23: return 1; // "rename file";
-	    case 30: return 1; // set attribute
-	    case 33: return 1; // "read random record";
-	    case 34: return 1; // "write random record";
-	    case 35: return 1; // "compute file size";
-	    case 36: return 1; // "set random record";
+	    case 15: return 1; /* "open file"; */
+	    case 16: return 1; /* "close file"; */
+	    case 17: return 1; /* "search for first"; */
+	    case 18: return 1; /* "search for next"; */
+	    case 19: return 1; /* "delete file (no wildcards yet)"; */
+	    case 20: return 1; /* "read sequential"; */
+	    case 21: return 1; /* "write sequential"; */
+	    case 22: return 1; /* "make file"; */
+	    case 23: return 1; /* "rename file"; */
+	    case 30: return 1; /* set attribute */
+	    case 33: return 1; /* "read random record"; */
+	    case 34: return 1; /* "write random record"; */
+	    case 35: return 1; /* "compute file size"; */
+	    case 36: return 1; /* "set random record"; */
 	    default: return 0;
 	}
 }
@@ -467,7 +467,7 @@ void check_BDOS_hook(z80info *z80) {
             B = H; A = L;
 	    F = 0;
 	    break;
-	}
+	} /* FALLTHRU */
 	case 0xfd:  HL = kget(0);
             B = H; A = L;
 	    F = 0;
@@ -616,7 +616,7 @@ void check_BDOS_hook(z80info *z80) {
 	break;
     case 16:	/* close file */
         {
-            size_t host_size, host_exts;
+            long host_size, host_exts;
 	    fp = getfp(z80, DE);
             fseek(fp, 0, SEEK_END);
             host_size = ftell(fp);

--- a/bios.c
+++ b/bios.c
@@ -115,7 +115,7 @@ closeall(z80info *z80)
 void
 warmboot(z80info *z80)
 {
-	int i;
+	unsigned int i;
 
 	closeall(z80);
 
@@ -344,12 +344,14 @@ list(z80info *z80)
 static void
 punch(z80info *z80)
 {
+	(void)z80;
 }
 
 /* return reader char in A, ^Z is EOF */
 static void
 reader(z80info *z80)
 {
+	(void)z80;
 	A = CNTL('Z');
 }
 
@@ -886,6 +888,7 @@ closeunix(z80info *z80)
 void
 finish(z80info *z80)
 {
+	(void)z80;
 	resetterm();
 	exit(0);
 }
@@ -930,7 +933,7 @@ dotime(z80info *z80)
 }
 
 void
-bios(z80info *z80, int fn)
+bios(z80info *z80, unsigned int fn)
 {
 	static void (*bioscall[])(z80info *z80) =
 	{
@@ -960,7 +963,7 @@ bios(z80info *z80, int fn)
 		dotime		/* 23 */
 	};
 
-	if (fn < 0 || fn >= sizeof bioscall / sizeof *bioscall)
+	if (fn >= sizeof bioscall / sizeof *bioscall)
 	{
 		fprintf(stderr, "Illegal BIOS call %d\r\n", fn);
 		return;

--- a/cpmtool.c
+++ b/cpmtool.c
@@ -584,26 +584,26 @@ int write_file(char *name, unsigned char *buf, long sects)
         int al[16]; /* Allocation map for current extent */
 
 
-        // Compute number of blocks needed for file
+        /* Compute number of blocks needed for file */
         blks = (sects + SECTORS_PER_BLOCK - 1) / SECTORS_PER_BLOCK;
 
-        // Compute number of extents needed for file
+        /* Compute number of extents needed for file */
         extents = ((blks * SECTORS_PER_BLOCK) + SECTORS_PER_EXTENT - 1) / SECTORS_PER_EXTENT;
-        // Force at least one extent for case of empty file
+        /* Force at least one extent for case of empty file */
         if (!extents)
                 extents = 1;
 
-        // Allocate space for file
+        /* Allocate space for file */
         blk_list = (int *)malloc(sizeof(int) * blks);
         if (alloc_space(blk_list, blks))
                 return -1;
 
-        // Allocate extents for file
+        /* Allocate extents for file */
         extent_list = (int *)malloc(sizeof(int) * extents);
         if (alloc_extents(extent_list, extents))
                 return -1;
 
-        // Write file
+        /* Write file */
         for (z = 0; z != 16; ++z)
                 al[z] = 0;
         blkno = 0;
@@ -663,12 +663,12 @@ int put_file(char *local_name, char *atari_name)
                 return -1;
         }
         rewind(f);
-        // Round up to a multiple of (SECTOR_SIZE)
+        /* Round up to a multiple of (SECTOR_SIZE) */
         up = size + (SECTOR_SIZE) - 1;
         up -= up % (SECTOR_SIZE);
 
         buf = (unsigned char *)malloc(up);
-        if (size != fread(buf, 1, size, f)) {
+        if (fread(buf, 1, size, f) != (size_t)size) {
                 printf("Couldn't read file '%s'\n", local_name);
                 fclose(f);
                 free(buf);
@@ -837,12 +837,12 @@ void atari_dir(int all, int full, int single)
 
 int mkfs()
 {
-        char buf[SECTOR_SIZE];
-        int x;
+        unsigned char buf[SECTOR_SIZE];
+        int tracks, x, n;
         for (x = 0; x != SECTOR_SIZE; ++x)
 	        buf[x] = 0xe5;
-        int tracks = dpb->off + (((dpb->dsm + 1) << dpb->bsh) + dpb->spt - 1) / dpb->spt;
-        int n = tracks * dpb->spt;
+        tracks = dpb->off + (((dpb->dsm + 1) << dpb->bsh) + dpb->spt - 1) / dpb->spt;
+        n = tracks * dpb->spt;
         printf("%d tracks\n", tracks);
         printf("%d sectors\n", n);
         for (x = 0; x != n; ++x)

--- a/defs.h
+++ b/defs.h
@@ -127,7 +127,7 @@ typedef unsigned long longword;
 typedef struct z80info
 {
     boolean event;
-//    byte regaf[2], regbc[2], regde[2], reghl[2];
+ /* byte regaf[2], regbc[2], regde[2], reghl[2]; */
     word regaf, regbc, regde, reghl;
     word regaf2, regbc2, regde2, reghl2;
     word regsp, regpc, regix, regiy;
@@ -275,13 +275,13 @@ extern void undefinstr(z80info *z80, byte instr);
 extern boolean loadfile(z80info *z80, const char *fname);
 
 /* bios.c */
-extern void bios(z80info *z80, int fn);
+extern void bios(z80info *z80, unsigned int fn);
 extern void sysreset(z80info *z80);
 extern void warmboot(z80info *z80);
 extern void finish(z80info *z80);
 
 /* disassem.c */
-extern int disassemlen(z80info *z80);
+extern int disassemlen(void);
 extern int disassem(z80info *z80, word start, FILE *fp);
 
 /* bdos */

--- a/disassem.c
+++ b/disassem.c
@@ -281,7 +281,7 @@ put_qq_reg(int reg_num)
 }
 
 int
-disassemlen(z80info *z80)
+disassemlen(void)
 {
 	return str_length;
 }

--- a/main.c
+++ b/main.c
@@ -116,7 +116,7 @@ initterm(void)
 	rawterm.c_cc[VERASE] = -1;
 	rawterm.c_cc[VKILL] = -1;
 
-	// tcsetattr(fileno(stdin), TCSADRAIN, &rawterm);
+	/* tcsetattr(fileno(stdin), TCSADRAIN, &rawterm); */
 
 #if 0
 	/* rawterm.c_lflag &= ~(ISIG | ICANON | ECHO); */
@@ -148,7 +148,7 @@ initterm(void)
 static void
 command(z80info *z80)
 {
-	int i, j, t, e;
+	unsigned int i, j, t, e;
 	char str[256], *s;
 	FILE *fp;
 	static word pe = 0;
@@ -307,7 +307,7 @@ loop:	/* "infinite" loop */
 
 		sscanf(str, "%x", &t);
 
-		if (t < 0 || t >= sizeof z80->mem)
+		if (t >= sizeof z80->mem)
 		{
 			printf("Cannot set breakpoint at addr 0x%X\n", t);
 			break;
@@ -341,7 +341,7 @@ loop:	/* "infinite" loop */
 
 		sscanf(str, "%x", &t);
 
-		if (t < 0 || t >= sizeof z80->mem)
+		if (t >= sizeof z80->mem)
 		{
 			printf("    Cannot clear breakpoint at addr 0x%X\n", t);
 			break;
@@ -370,7 +370,7 @@ loop:	/* "infinite" loop */
 			printf("  %.4X:    ", pe);
 			j = pe;
 			pe += disassem(z80, pe, stdout);
-			t = disassemlen(z80);
+			t = disassemlen();
 
 			while (t++ < 15)
 				putchar(' ');
@@ -734,7 +734,7 @@ loadfile(z80info *z80, const char *fname)
 boolean
 input(z80info *z80, byte haddr, byte laddr, byte *val)
 {
-	int data;
+	unsigned int data;
 
 	/* just uses the lower 8-bits of the I/O address for now... */
 	switch (laddr)
@@ -777,14 +777,14 @@ input(z80info *z80, byte haddr, byte laddr, byte *val)
 #else	/* TCGETA */
 			fflush(stdout);
 			data = kget(0);
-//			data = getchar();
+			/* data = getchar(); */
 
-			while ((data < 0 && errno == EINTR) ||
+			while ((data > 0x7f && errno == EINTR) ||
 					data == INTR_CHAR)
 			{
 				command(z80);
 				data = kget(0);
-//				data = getchar();
+				/* data = getchar(); */
 			}
 #endif
 		}
@@ -855,7 +855,7 @@ output(z80info *z80, byte haddr, byte laddr, byte data)
 		}
 	} else if (laddr == 0) {
 		/* output a character to the screen */
-		// putchar(data);
+		/* putchar(data); */
 		vt52(data);
 
 		if (logfile != NULL)
@@ -1028,7 +1028,7 @@ main(int argc, const char *argv[])
 
 	cmd[0] = 0;
 
-	for (x = 1; argv[x]; ++x) {
+	for (x = 1; x < argc; ++x) {
 		if (argv[x][0] == '-' && argv[x][1] == '-') {
 			if (!strcmp(argv[x], "--help")) {
 				help = 1;


### PR DESCRIPTION
Don't use C++ comments
Fix unsigned/signed integer comparisons
Enable all and extra warnings
void out all unused arguments
remove unnecessary arguments from functions where they won't be needed
other small fixes

Let me know if there's anything else I can change.