### PR TITLE
Added --exec option and implemented single command execution

### DIFF
--- a/bdos.c
+++ b/bdos.c
@@ -21,7 +21,20 @@ unsigned short usercode = 0x00;
 int restricted_mode = 0;
 int silent_exit = 0;
 char *stuff_cmd = 0;
+int exec = 0;
 int trace_bdos = 0;
+
+/* Kill CP/M command line prompt */
+
+static void killprompt()
+{
+    vt52('\b');
+    vt52(' ');
+    vt52('\b');
+    vt52('\b');
+    vt52(' ');
+    vt52('\b');
+}
 
 char *rdcmdline(z80info *z80, int max, int ctrl_c_enable)
 {
@@ -33,19 +46,18 @@ char *rdcmdline(z80info *z80, int max, int ctrl_c_enable)
     i = 1;      /* number of next character */
 
     if (stuff_cmd) {
-    	/* Kill prompt */
-    	vt52('\b');
-    	vt52(' ');
-    	vt52('\b');
-    	vt52('\b');
-    	vt52(' ');
-    	vt52('\b');
+        killprompt();
     	strcpy(s + i, stuff_cmd);
     	/* printf("'%s'\n", stuff_cmd); */
     	i = 1 + strlen(s + i);
     	stuff_cmd = 0;
     	silent_exit = 1;
     	goto hit_rtn;
+    } else if (exec) {
+        killprompt();
+        printf("\r\n");
+        finish(z80);
+        return s;
     }
 
 loop:

--- a/defs.h
+++ b/defs.h
@@ -291,6 +291,7 @@ extern int disassem(z80info *z80, word start, FILE *fp);
 void check_BDOS_hook(z80info *z80);
 extern int silent_exit;
 extern char *stuff_cmd;
+extern int exec;
 extern int trace_bdos;
 extern int strace;
 char *bdos_decode(int n);

--- a/main.c
+++ b/main.c
@@ -1053,6 +1053,8 @@ main(int argc, const char *argv[])
 		if (argv[x][0] == '-' && argv[x][1] == '-') {
 			if (!strcmp(argv[x], "--help")) {
 				help = 1;
+			} else if (!strcmp(argv[x], "--exec")) {
+				exec = 1;
 			} else if (!strcmp(argv[x], "--nobdos")) {
 				nobdos = 1;
 			} else if (!strcmp(argv[x], "--trace_bdos")) {
@@ -1077,6 +1079,7 @@ main(int argc, const char *argv[])
 		fprintf(stderr, "\n%s [options] [CP/M command]\n", argv[0]);
 		fprintf(stderr, "\n   Options:\n\n");
 		fprintf(stderr, "    --help         Show this help\n");
+		fprintf(stderr, "    --exec         Execute the command and exit\n");
 		fprintf(stderr, "    --nobdos       Do not emulate BDOS: only emulate BIOS\n");
 		fprintf(stderr, "                   Real disk images will be used.        \n");
 		fprintf(stderr, "    --trace_bdos   Trace BDOS calls\n");


### PR DESCRIPTION
_I was very pleased with your implementation of CP/M container and how naturally it fits into a command line environment. Well done!_

This pull requests adds a command line option "_--exec_" that causes the application to run a single command, if provided, and exit.

The newly introduced functionality makes it somewhat easier to integrate **cpm** is the cross-platform (retro) development environments (be they IDE-based or vim) in which the sources are edited and kept in a version control system outside, but the compilers are run within the CP/M container.

Please note, that with the introduction of the new option, the "command" token remains optional, meaning that `./cpm --exec` is effectively a no-op call that is similar to `./cpm bye`. I decided against putting an error check in `main.c` against this combination for now.

I have made an effort to reduce the changes to the bare minimum.

Sample commands:
`cpm --exec dir`
`cpm --exec gen80 hello.gen`

