### PR TITLE
Fixed BDOS 16 missing FCB bug

### DIFF
--- a/bdos.c
+++ b/bdos.c
@@ -617,7 +617,13 @@ void check_BDOS_hook(z80info *z80) {
     case 16:	/* close file */
         {
             long host_size, host_exts;
-	    fp = getfp(z80, DE);
+
+	    if (!(fp = lookfp(z80, DE))) {
+		/* if the FBC is unknown, return an error */
+		HL = 0xFF;
+		B = H, A = L;
+		break;
+	    }
             fseek(fp, 0, SEEK_END);
             host_size = ftell(fp);
             host_exts = SEQ_EXTENT(host_size);


### PR DESCRIPTION
The proposed pull request fixes an early exit from **cpm** VM caused by BDOS 16 call with the unknown FCB. The application is expected to be resilient to this behaviour and the respective BDOS call should return an error.

Steps to reproduce the problem from **cpm** root directory:
```
bash-3.2$ cd tests
bash-3.2$ ../cpm

A>ed
error: cannot find fp entry for FCB at 1b3d fctn 16, FCB named 
ED      COM d49b

bash-3.2$
```
followed by the exit to shell.

Expected behaviour of ED when running **cpm** in its root directory without **bdos** extensions:
```
bash-3.2$ ./cpm

A>bye 
bash-3.2$ ./cpm --nobdos

A>ed 

DISK OR DIRECTORY FULL

A>
```

**After the fix**, ED behaves as expected:
```
bash-3.2$ cd tests
bash-3.2$ ../cpm

A>ed

DISK OR DIRECTORY FULL

A>
```

I hope this helps! :-)