### PR TITLE
Modularising the emulator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 cpm
 cpmtool
 nbproject/*
+experiment/*

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,8 @@ CFLAGS = -g -pipe -Wall -Wextra -pedantic -ansi \
 LDFLAGS = 
 
 FILES = README.md Makefile A-Hdrive B-Hdrive cpmws.png \
-	bdos.c bdos.h bios.c cpm.c cpmdisc.h defs.h disassem.c main.c vt.c vt.h z80.c \
+	bdos.c bdos.h bios.c bios.h cpm.c cpmdisc.h defs.h disassem.c disassem.h \
+	main.c vm.h vt.c vt.h z80.c z80.h \
 	bye.mac getunix.mac putunix.mac cpmtool.c
 
 OBJS =	bios.o \
@@ -39,7 +40,7 @@ cpm$(EXE): $(OBJS)
 
 
 bios.o:		bios.c defs.h cpmdisc.h cpm.c
-z80.o:		z80.c defs.h
+z80.o:		z80.c z80.h defs.h
 disassem.o:	disassem.c defs.h
 main.o:		main.c defs.h
 

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ CFLAGS = -g -pipe -Wall -Wextra -pedantic -ansi \
 LDFLAGS = 
 
 FILES = README.md Makefile A-Hdrive B-Hdrive cpmws.png \
-	bdos.c bios.c cpm.c cpmdisc.h defs.h disassem.c main.c vt.c vt.h z80.c \
+	bdos.c bdos.h bios.c cpm.c cpmdisc.h defs.h disassem.c main.c vt.c vt.h z80.c \
 	bye.mac getunix.mac putunix.mac cpmtool.c
 
 OBJS =	bios.o \

--- a/bdos.c
+++ b/bdos.c
@@ -10,6 +10,7 @@
 
 #include "defs.h"
 #include "bdos.h"
+#include "vm.h"
 #include "vt.h"
 
 #define BIOS 0xFE00

--- a/bdos.c
+++ b/bdos.c
@@ -9,6 +9,7 @@
 #include <unistd.h>
 
 #include "defs.h"
+#include "bdos.h"
 #include "vt.h"
 
 #define BIOS 0xFE00

--- a/bdos.c
+++ b/bdos.c
@@ -149,6 +149,8 @@ loop:
 	fflush(stdout);
     }
     goto loop;
+    /* Never reached */
+    return NULL;
 }
 
 
@@ -539,7 +541,8 @@ void bdos_check_hook(bdos *obj, z80info *z80) {
             B = H; A = L;
 	    F = 0;
 	    break;
-	} /* FALLTHRU */
+	}
+	/* no break */
 	case 0xfd:  HL = kget(0);
             B = H; A = L;
 	    F = 0;
@@ -728,7 +731,7 @@ void bdos_check_hook(bdos *obj, z80info *z80) {
 	    exit(1);
 	}
 	obj->sfn = DE;
-	/* fall through */
+	/* no break */
     case 18:	/* search for next */
 	if (!obj->dp)
 	    goto retbad;
@@ -915,7 +918,7 @@ void bdos_check_hook(bdos *obj, z80info *z80) {
     case 35:	/* compute file size */
 	fp = getfp(obj, z80, DE);
 	fseek(fp, 0L, SEEK_END);
-	/* fall through */
+	/* no break */
     case 36:	/* set random record */
 	fp = getfp(obj, z80, DE);
 	{   

--- a/bdos.c
+++ b/bdos.c
@@ -429,7 +429,7 @@ void bdos_fcb_dump(z80info *z80)
 }
 
 /* Calculates the file size */
-unsigned long filesize(FILE *fp)
+static unsigned long filesize(FILE *fp)
 {
     struct stat stbuf;
     unsigned long r;
@@ -444,7 +444,7 @@ unsigned long filesize(FILE *fp)
 
 /* Get count of records in current extent */
 
-int fixrc(z80info *z80, FILE *fp)
+static int fixrc(z80info *z80, FILE *fp)
 {
     struct stat stbuf;
     unsigned long size;

--- a/bdos.c
+++ b/bdos.c
@@ -785,20 +785,11 @@ void check_BDOS_hook(z80info *z80) {
         } else {
             HL = 0x00;
         }
-        B = H; A = L;
-
-/*
-	    z80->mem[DE + FCB_CR] = SEQ_CR(ofst);
-	    z80->mem[DE + FCB_EX] = SEQ_EX(ofst);
-	    z80->mem[DE + FCB_S2] = (0x80 | SEQ_S2(ofst));
-*/
         /* fixrc(z80, fp); */
-	    HL = 0x00;
-            B = H; A = L;
 	} else {
 	    HL = 0x1;	/* ff => pip error */
-            B = H; A = L;
 	}    
+        B = H; A = L;
 	break;
     case 21:	/* write sequential */
 	fp = getfp(z80, DE);
@@ -865,11 +856,10 @@ void check_BDOS_hook(z80info *z80) {
 	    z80->mem[DE + FCB_EX] = (ofst >> 7) & 0x1f;
 	    z80->mem[DE + FCB_S2] = (ofst >> 12) & 0xff;
 	    HL = 0x00;
-            B = H; A = L;
 	} else {
 	    HL = 0x1;	/* ff => pip error */
-	    B = H; A = L;
 	}
+	    B = H; A = L;
 	}
 	break;
     case 34:	/* write random record */

--- a/bdos.c
+++ b/bdos.c
@@ -436,7 +436,7 @@ unsigned long filesize(FILE *fp)
         return 0;
     }
     r = stbuf.st_size % BlkSZ;
-    return r ? stbuf.st_size + BlkSZ - r : stbuf.st_size;
+    return r ? (unsigned)stbuf.st_size + BlkSZ - r : (unsigned)stbuf.st_size;
 
 }
 

--- a/bdos.h
+++ b/bdos.h
@@ -1,0 +1,20 @@
+#ifndef __BDOS_H_
+#define __BDOS_H_
+
+/* bdos class */
+
+typedef struct bdos_s bdos;
+
+#define BDOS_HOOK 0xDC06
+
+bdos *bdos_new(vm *vm, bios *bios);
+void bdos_set_cmd(bdos *obj, char *cmd);
+void bdos_set_exec(bdos *obj, int exec);
+void bdos_set_trace_bdos(bdos *obj, int trace_bdos);
+void bdos_check_hook(bdos *obj, z80info *z80);
+char *bdos_decode(int n);
+int bdos_fcb(int n);
+void bdos_fcb_dump(z80info *z80);
+void bdos_destroy(bdos *obj);
+
+#endif /* __BDOS_H_ */

--- a/bdos.h
+++ b/bdos.h
@@ -1,6 +1,9 @@
 #ifndef __BDOS_H_
 #define __BDOS_H_
 
+#include "defs.h"
+#include "bios.h"
+
 /* bdos class */
 
 typedef struct bdos_s bdos;

--- a/bios.c
+++ b/bios.c
@@ -726,7 +726,7 @@ int2addr(unsigned char *addr, int val)
 
 FILE *cpm_file[CPM_FILES];
 
-int cpm_file_alloc(FILE *f)
+static int cpm_file_alloc(FILE *f)
 {
 	int x;
 	for (x = 0; x != CPM_FILES; ++x)
@@ -737,7 +737,7 @@ int cpm_file_alloc(FILE *f)
 	return -1;
 }
 
-FILE *cpm_file_get(int idx)
+static FILE *cpm_file_get(int idx)
 {
 	if (idx < 0 || idx > CPM_FILES)
 		return 0;
@@ -745,7 +745,7 @@ FILE *cpm_file_get(int idx)
 		return cpm_file[idx];
 }
 
-int cpm_file_free(int x)
+static int cpm_file_free(int x)
 {
 	if (x >= 0 && x < CPM_FILES && cpm_file[x]) {
 		int rtn = fclose(cpm_file[x]);

--- a/bios.c
+++ b/bios.c
@@ -92,6 +92,7 @@
 #define USER		0x000A
 #define USERSTART	0x0100
 
+int silent_exit = 0;
 
 /* forward declarations: */
 static void seldisc(z80info *z80);

--- a/bios.c
+++ b/bios.c
@@ -979,6 +979,7 @@ dotime(bios *obj, z80info *z80)
     struct tm *t;
     word days;
     int y;
+    (void)obj;
 
     if (C != 0)		/* do not support setting the time yet */
 		return;

--- a/bios.c
+++ b/bios.c
@@ -16,8 +16,11 @@
 #include <string.h>
 #include <time.h>
 #include <sys/types.h>
+#include "bios.h"
+#include "vm.h"
 #include "cpmdisc.h"
 #include "defs.h"
+#include "z80.h"
 
 #ifdef macintosh
 #include <stat.h>

--- a/bios.h
+++ b/bios.h
@@ -3,6 +3,7 @@
 
 #include "defs.h"
 #include "z80.h"
+#include "vm.h"
 
 /* bios.c class */
 typedef struct bios_s bios;

--- a/bios.h
+++ b/bios.h
@@ -8,6 +8,8 @@
 typedef struct bios_s bios;
 
 bios *bios_new(vm *vm);
+word bios_get_dma(bios *obj);
+void bios_set_dma(bios *obj, word dma);
 void bios_set_silent_exit(bios *obj, int silent_exit);
 void bios_call(bios *obj, z80info *z80, unsigned int fn);
 void bios_sysreset(bios *obj, z80info *z80);

--- a/bios.h
+++ b/bios.h
@@ -1,0 +1,18 @@
+#ifndef __BIOS_H_
+#define __BIOS_H_
+
+#include "defs.h"
+#include "z80.h"
+
+/* bios.c class */
+typedef struct bios_s bios;
+
+bios *bios_new(vm *vm);
+void bios_set_silent_exit(bios *obj, int silent_exit);
+void bios_call(bios *obj, z80info *z80, unsigned int fn);
+void bios_sysreset(bios *obj, z80info *z80);
+void bios_warmboot(bios *obj, z80info *z80);
+void bios_finish(bios *obj, z80info *z80);
+void bios_destroy(bios *obj);
+
+#endif /* __BIOS_H_ */

--- a/defs.h
+++ b/defs.h
@@ -11,7 +11,7 @@
 #include <stdio.h>
 
 /* the current version of the z80 emulator */
-#define VERSION "3.1"
+#define VERSION "3.1e"
 
 
 /* system definitions */
@@ -125,7 +125,7 @@ typedef unsigned long longword;
 /* max number of the BIOS drive tables */
 #define MAXDISCS	16
 
-
+/* TODO: Move the states irrelevant to the CPU to the respective classes */
 typedef struct z80info
 {
     boolean event;
@@ -257,17 +257,17 @@ typedef struct z80info
 #define EVENT	z80->event
 
 
+/* TODO: Create individual header files for newly introduced classes */
 /* function externs: */
 
-/* z80.c */
+/* z80.c class */
 extern z80info *z80_new(void);
 extern void z80_set_interceptor(z80info *z80, void *intercept_ctx,
         void (*intercept)(void *, struct z80info *));
 extern boolean z80_run(z80info *z80, int count);
 extern void z80_destroy(z80info *z80);
 
-extern int nobdos;
-
+/* TODO: Turn into a class */
 /* main.c */
 extern void resetterm(void);
 extern void setterm(void);
@@ -279,26 +279,30 @@ extern word write_mem(z80info *z80, word addr, byte val);
 extern void undefinstr(z80info *z80, byte instr);
 extern boolean loadfile(z80info *z80, const char *fname);
 
+/* TODO: Turn into a class */
 /* bios.c */
 extern void bios(z80info *z80, unsigned int fn);
 extern void sysreset(z80info *z80);
 extern void warmboot(z80info *z80);
 extern void finish(z80info *z80);
+extern int silent_exit;
 
 /* disassem.c */
 extern int disassemlen(void);
 extern int disassem(z80info *z80, word start, FILE *fp);
 
-/* bdos */
+/* bdos class */
+typedef struct bdos_s bdos;
+
 #define BDOS_HOOK 0xDC06
-void check_BDOS_hook(z80info *z80);
-extern int silent_exit;
-extern char *stuff_cmd;
-extern int exec;
-extern int trace_bdos;
-extern int strace;
+bdos *bdos_new();
+void bdos_set_cmd(bdos *obj, char *cmd);
+void bdos_set_exec(bdos *obj, int exec);
+void bdos_set_trace_bdos(bdos *obj, int trace_bdos);
+void bdos_check_hook(bdos *obj, z80info *z80);
 char *bdos_decode(int n);
 int bdos_fcb(int n);
 void bdos_fcb_dump(z80info *z80);
+void bdos_destroy(bdos *obj);
 
 #endif /* __DEFS_H_ */

--- a/defs.h
+++ b/defs.h
@@ -125,6 +125,8 @@ typedef unsigned long longword;
 /* max number of the BIOS drive tables */
 #define MAXDISCS	16
 
+typedef struct vm_s vm;
+
 /* TODO: Move the states irrelevant to the CPU to the respective classes */
 typedef struct z80info
 {
@@ -145,13 +147,7 @@ typedef struct z80info
     word *regixy[2];
     byte *regir[2];
 
-    /* these are for the I/O, CP/M, and outside needs */
-    boolean trace;		/* trace mode off/on */
-    boolean step;		/* step-trace mode off/on */
-    int sig;		/* caught a signal */
-    int syscall;	/* CP/M syscall to be done */
-    int biosfn;		/* BIOS function be done */
-
+    /* TODO: These belong to the BIOS state */
     /* these are for the CP/M BIOS */
     int	drive;
     word dma;
@@ -163,6 +159,9 @@ typedef struct z80info
     /* Private: CPU Interceptor is invoked on each and every loop */
     void *intercept_ctx;
     void (*intercept)(void *, struct z80info *);
+
+    /* Virtual Machine pointer */
+    vm *vm;
 
     /* 64k bytes - may be allocated separately if desired */
     byte mem[0x10000L];
@@ -191,11 +190,11 @@ typedef struct z80info
 #ifdef MEM_BREAK
 #    define MEM(addr)	\
 		(z80->membrk[(word)(addr)] ?	\
-		read_mem(z80, addr) :	\
+		vm_read_mem(obj->vm, z80, addr) :	\
 		z80->mem[(word)(addr)])
 #    define SETMEM(addr, val)	\
 		(z80->membrk[(word)(addr)] ?	\
-		write_mem(z80, addr, val) :	\
+		vm_write_mem(obj->vm, z80, addr, val) :	\
 		(z80->mem[(word)(addr)] = (byte)(val)))
 
 	/* various flags for "membrk" - others may be added */
@@ -261,31 +260,36 @@ typedef struct z80info
 /* function externs: */
 
 /* z80.c class */
-extern z80info *z80_new(void);
-extern void z80_set_interceptor(z80info *z80, void *intercept_ctx,
-        void (*intercept)(void *, struct z80info *));
-extern boolean z80_run(z80info *z80, int count);
-extern void z80_destroy(z80info *z80);
+z80info *z80_new(vm *vm);
+void z80_set_interceptor(z80info *z80, void *intercept_ctx,
+		void (*intercept)(void *, struct z80info *));
+boolean z80_run(z80info *z80, int count);
+void z80_destroy(z80info *z80);
 
-/* TODO: Turn into a class */
-/* main.c */
-extern void resetterm(void);
-extern void setterm(void);
-extern boolean input(z80info *z80, byte haddr, byte laddr, byte *val);
-extern void output(z80info *z80, byte haddr, byte laddr, byte data);
-extern void haltcpu(z80info *z80);
-extern word read_mem(z80info *z80, word addr);
-extern word write_mem(z80info *z80, word addr, byte val);
-extern void undefinstr(z80info *z80, byte instr);
-extern boolean loadfile(z80info *z80, const char *fname);
+/* main.c contains vm class */
 
-/* TODO: Turn into a class */
-/* bios.c */
-extern void bios(z80info *z80, unsigned int fn);
-extern void sysreset(z80info *z80);
-extern void warmboot(z80info *z80);
-extern void finish(z80info *z80);
-extern int silent_exit;
+vm *vm_new();
+void vm_resetterm(vm *obj);
+void vm_setterm(vm *obj);
+boolean vm_input(vm *obj, z80info *z80, byte haddr, byte laddr, byte *val);
+void vm_output(vm *obj, z80info *z80, byte haddr, byte laddr, byte data);
+void vm_haltcpu(vm *obj, z80info *z80);
+word vm_read_mem(vm *obj, z80info *z80, word addr);
+word vm_write_mem(vm *obj, z80info *z80, word addr, byte val);
+void vm_undefinstr(vm *obj, z80info *z80, byte instr);
+boolean vm_loadfile(z80info *z80, const char *fname);
+void vm_destroy(vm *obj);
+
+/* bios.c class */
+typedef struct bios_s bios;
+
+bios *bios_new(vm *vm);
+void bios_set_silent_exit(bios *obj, int silent_exit);
+void bios_call(bios *obj, z80info *z80, unsigned int fn);
+void bios_sysreset(bios *obj, z80info *z80);
+void bios_warmboot(bios *obj, z80info *z80);
+void bios_finish(bios *obj, z80info *z80);
+void bios_destroy(bios *obj);
 
 /* disassem.c */
 extern int disassemlen(void);
@@ -295,7 +299,7 @@ extern int disassem(z80info *z80, word start, FILE *fp);
 typedef struct bdos_s bdos;
 
 #define BDOS_HOOK 0xDC06
-bdos *bdos_new();
+bdos *bdos_new(vm *vm, bios *bios);
 void bdos_set_cmd(bdos *obj, char *cmd);
 void bdos_set_exec(bdos *obj, int exec);
 void bdos_set_trace_bdos(bdos *obj, int trace_bdos);

--- a/defs.h
+++ b/defs.h
@@ -160,6 +160,10 @@ typedef struct z80info
     FILE *drives[MAXDISCS];
     long drivelen[MAXDISCS];
 
+    /* Private: CPU Interceptor is invoked on each and every loop */
+    void *intercept_ctx;
+    void (*intercept)(void *, struct z80info *);
+
     /* 64k bytes - may be allocated separately if desired */
     byte mem[0x10000L];
 
@@ -257,8 +261,10 @@ typedef struct z80info
 
 /* z80.c */
 extern z80info *z80_new(void);
-extern void z80_destroy(z80info *z80);
+extern void set_interceptor(z80info *z80, void *intercept_ctx,
+        void (*intercept)(void *, struct z80info *));
 extern boolean z80_run(z80info *z80, int count);
+extern void z80_destroy(z80info *z80);
 
 extern int nobdos;
 

--- a/defs.h
+++ b/defs.h
@@ -8,11 +8,8 @@
 #ifndef __DEFS_H_
 #define __DEFS_H_
 
-#include <stdio.h>
-
 /* the current version of the z80 emulator */
 #define VERSION "3.1e"
-
 
 /* system definitions */
 #if defined THINK_C || defined applec || defined macintosh
@@ -42,7 +39,6 @@
 #   endif
 #endif
 
-
 /* misc. handy defs */
 
 #ifndef TRUE
@@ -55,9 +51,7 @@
 
 typedef int boolean;
 
-
 #define CNTL(c) ((c) & 037)	/* convert a char to its control equivalent */
-
 
 /* handy typedefs for an 8-bit byte, 16-bit word, & 32-bit longword */
 
@@ -65,234 +59,7 @@ typedef unsigned char byte;
 typedef unsigned short word;
 typedef unsigned long longword;
 
-
-/* handy bit definitions - bit fields are not used as they are generally
-   much slower than the equivalent logical masking operations */
-
-#define BIT16  0x10000L
-#define BIT15   0x8000
-#define BIT14   0x4000
-#define BIT13   0x2000
-#define BIT12   0x1000
-#define BIT11   0x0800
-#define BIT10   0x0400
-#define BIT9    0x0200
-#define BIT8    0x0100
-#define BIT7    0x0080
-#define BIT6    0x0040
-#define BIT5    0x0020
-#define BIT4    0x0010
-#define BIT3    0x0008
-#define BIT2    0x0004
-#define BIT1    0x0002
-#define BIT0    0x0001
-
-/* handy masks to get a particular number of bits out */
-
-#define MASK1   0x01
-#define MASK2   0x03
-#define MASK3   0x07
-#define MASK4   0x0F
-#define MASK5   0x1F
-#define MASK6   0x3F
-#define MASK7   0x7F
-#define MASK8   0xFF
-#define MASK12  0xFFF
-
-#define MASKU4  0xF0
-#define MASK16  0xFFFF
-
-
-/* z80 flag register definitions */
-
-#define SIGN      0x80
-#define ZERO      0x40
-#define HALF      0x10
-#define PARITY    0x04
-#define OVERFLOW  PARITY
-#define NEGATIVE  0x02
-#define CARRY     0x01
-
-
-/* z80 interrupt types - used to set the intr struct var */
-
-#define INTRMASK	0xF00
-#define INT_FLAG	0x100
-#define NM_FLAG		0x200
-#define RESET_FLAG	0x400
-
-
-/* max number of the BIOS drive tables */
-#define MAXDISCS	16
-
+/* TODO: Move this to vm.h when the dependency tree is stable */
 typedef struct vm_s vm;
-
-/* TODO: Move the states irrelevant to the CPU to the respective classes */
-typedef struct z80info
-{
-    boolean event;
- /* byte regaf[2], regbc[2], regde[2], reghl[2]; */
-    word regaf, regbc, regde, reghl;
-    word regaf2, regbc2, regde2, reghl2;
-    word regsp, regpc, regix, regiy;
-    byte regi, regr;
-    byte iff, iff2, imode;
-    byte reset, nmi, intr, halt;
-
-    /* these point to the addresses of the above registers */
-    byte *reg[8];
-    word *regpairaf[4];
-    word *regpairsp[4];
-    word *regpairxy[4];
-    word *regixy[2];
-    byte *regir[2];
-
-    /* TODO: These belong to the BIOS state */
-    /* these are for the CP/M BIOS */
-    int	drive;
-    word dma;
-    word track;
-    word sector;
-    FILE *drives[MAXDISCS];
-    long drivelen[MAXDISCS];
-
-    /* Private: CPU Interceptor is invoked on each and every loop */
-    void *intercept_ctx;
-    void (*intercept)(void *, struct z80info *);
-
-    /* Virtual Machine pointer */
-    vm *vm;
-
-    /* 64k bytes - may be allocated separately if desired */
-    byte mem[0x10000L];
-
-#ifdef MEM_BREAK
-    /* one for each byte of memory for breaks, memory-mapped I/O, etc */
-    byte membrk[0x10000L];
-    long numbrks;
-#endif
-} z80info;
-
-
-/* All the following macros assume that a variable named "z80" is
-   available to access the above info.  This is to allow multiple
-   z80s to run without stepping on each other.
-*/
-
-
-/* These macros allow memory-mapped I/O if MEM_BREAK is defined.
-   Because of this, these macros must be very carefully used, and
-   there must not be ANY side-effects, such as increment/decerement
-   in any of the macro args.  Customizations go into read_mem() and
-   write_mem().
-*/
-
-#ifdef MEM_BREAK
-#    define MEM(addr)	\
-		(z80->membrk[(word)(addr)] ?	\
-		vm_read_mem(obj->vm, z80, addr) :	\
-		z80->mem[(word)(addr)])
-#    define SETMEM(addr, val)	\
-		(z80->membrk[(word)(addr)] ?	\
-		vm_write_mem(obj->vm, z80, addr, val) :	\
-		(z80->mem[(word)(addr)] = (byte)(val)))
-
-	/* various flags for "membrk" - others may be added */
-#	define M_BREAKPOINT	0x01		/* breakpoint */
-#	define M_READ_PROTECT	0x02		/* read-protected memory */
-#	define M_WRITE_PROTECT	0x04		/* write-protected memory */
-#	define M_MEM_MAPPED_IO	0x08		/* memory-mapped I/O addr */
-
-#else
-#    define MEM(addr) z80->mem[(word)(addr)]
-#    define SETMEM(addr, val) (z80->mem[(word)(addr)] = (byte)(val))
-#endif
-
-
-/* how to access the z80 registers & register pairs */
-
-#ifdef ENDIAN_LITTLE
-#  define A	((unsigned char *)&z80->regaf)[1]
-#  define F	((unsigned char *)&z80->regaf)[0]
-#  define B	((unsigned char *)&z80->regbc)[1]
-#  define C	((unsigned char *)&z80->regbc)[0]
-#  define D	((unsigned char *)&z80->regde)[1]
-#  define E	((unsigned char *)&z80->regde)[0]
-#  define H	((unsigned char *)&z80->reghl)[1]
-#  define L	((unsigned char *)&z80->reghl)[0]
-#else
-#  define A	((unsigned char *)&z80->regaf)[0]
-#  define F	((unsigned char *)&z80->regaf)[1]
-#  define B	((unsigned char *)&z80->regbc)[0]
-#  define C	((unsigned char *)&z80->regbc)[1]
-#  define D	((unsigned char *)&z80->regde)[0]
-#  define E	((unsigned char *)&z80->regde)[1]
-#  define H	((unsigned char *)&z80->reghl)[0]
-#  define L	((unsigned char *)&z80->reghl)[1]
-#endif
-
-#define I	z80->regi
-#define R	z80->regr
-#define AF	z80->regaf
-#define BC	z80->regbc
-#define DE	z80->regde
-#define HL	z80->reghl
-#define AF2	z80->regaf2
-#define BC2	z80->regbc2
-#define DE2	z80->regde2
-#define HL2	z80->reghl2
-#define SP	z80->regsp
-#define PC	z80->regpc
-#define IX	z80->regix
-#define IY	z80->regiy
-#define IFF	z80->iff
-#define IFF2	z80->iff2
-#define IMODE	z80->imode
-#define RESET	z80->reset
-#define NMI	z80->nmi
-#define INTR	z80->intr
-#define HALT	z80->halt
-
-#define EVENT	z80->event
-
-
-/* TODO: Create individual header files for newly introduced classes */
-/* function externs: */
-
-/* z80.c class */
-z80info *z80_new(vm *vm);
-void z80_set_interceptor(z80info *z80, void *intercept_ctx,
-		void (*intercept)(void *, struct z80info *));
-boolean z80_run(z80info *z80, int count);
-void z80_destroy(z80info *z80);
-
-/* main.c contains vm class */
-
-vm *vm_new();
-void vm_resetterm(vm *obj);
-void vm_setterm(vm *obj);
-boolean vm_input(vm *obj, z80info *z80, byte haddr, byte laddr, byte *val);
-void vm_output(vm *obj, z80info *z80, byte haddr, byte laddr, byte data);
-void vm_haltcpu(vm *obj, z80info *z80);
-word vm_read_mem(vm *obj, z80info *z80, word addr);
-word vm_write_mem(vm *obj, z80info *z80, word addr, byte val);
-void vm_undefinstr(vm *obj, z80info *z80, byte instr);
-boolean vm_loadfile(z80info *z80, const char *fname);
-void vm_destroy(vm *obj);
-
-/* bios.c class */
-typedef struct bios_s bios;
-
-bios *bios_new(vm *vm);
-void bios_set_silent_exit(bios *obj, int silent_exit);
-void bios_call(bios *obj, z80info *z80, unsigned int fn);
-void bios_sysreset(bios *obj, z80info *z80);
-void bios_warmboot(bios *obj, z80info *z80);
-void bios_finish(bios *obj, z80info *z80);
-void bios_destroy(bios *obj);
-
-/* disassem.c */
-extern int disassemlen(void);
-extern int disassem(z80info *z80, word start, FILE *fp);
 
 #endif /* __DEFS_H_ */

--- a/defs.h
+++ b/defs.h
@@ -295,18 +295,4 @@ void bios_destroy(bios *obj);
 extern int disassemlen(void);
 extern int disassem(z80info *z80, word start, FILE *fp);
 
-/* bdos class */
-typedef struct bdos_s bdos;
-
-#define BDOS_HOOK 0xDC06
-bdos *bdos_new(vm *vm, bios *bios);
-void bdos_set_cmd(bdos *obj, char *cmd);
-void bdos_set_exec(bdos *obj, int exec);
-void bdos_set_trace_bdos(bdos *obj, int trace_bdos);
-void bdos_check_hook(bdos *obj, z80info *z80);
-char *bdos_decode(int n);
-int bdos_fcb(int n);
-void bdos_fcb_dump(z80info *z80);
-void bdos_destroy(bdos *obj);
-
 #endif /* __DEFS_H_ */

--- a/defs.h
+++ b/defs.h
@@ -59,7 +59,4 @@ typedef unsigned char byte;
 typedef unsigned short word;
 typedef unsigned long longword;
 
-/* TODO: Move this to vm.h when the dependency tree is stable */
-typedef struct vm_s vm;
-
 #endif /* __DEFS_H_ */

--- a/defs.h
+++ b/defs.h
@@ -39,17 +39,7 @@
 #   endif
 #endif
 
-/* misc. handy defs */
-
-#ifndef TRUE
-#define TRUE	1
-#endif
-
-#ifndef FALSE
-#define FALSE	0
-#endif
-
-typedef int boolean;
+typedef enum { FALSE, TRUE } boolean;
 
 #define CNTL(c) ((c) & 037)	/* convert a char to its control equivalent */
 

--- a/defs.h
+++ b/defs.h
@@ -261,7 +261,7 @@ typedef struct z80info
 
 /* z80.c */
 extern z80info *z80_new(void);
-extern void set_interceptor(z80info *z80, void *intercept_ctx,
+extern void z80_set_interceptor(z80info *z80, void *intercept_ctx,
         void (*intercept)(void *, struct z80info *));
 extern boolean z80_run(z80info *z80, int count);
 extern void z80_destroy(z80info *z80);

--- a/defs.h
+++ b/defs.h
@@ -256,12 +256,9 @@ typedef struct z80info
 /* function externs: */
 
 /* z80.c */
-extern z80info *new_z80info(void);
-extern z80info *init_z80info(z80info *z80);
-extern z80info *destroy_z80info(z80info *z80);
-extern void delete_z80info(z80info *z80);
-
-extern boolean z80_emulator(z80info *z80, int count);
+extern z80info *z80_new(void);
+extern void z80_destroy(z80info *z80);
+extern boolean z80_run(z80info *z80, int count);
 
 extern int nobdos;
 

--- a/disassem.c
+++ b/disassem.c
@@ -12,7 +12,7 @@
 #include <stdio.h>
 #include <string.h>
 #include "defs.h"
-
+#include "disassem.h"
 
 #define bits(l,r) (((z80->mem[loc]) >> (r)) & mask[(l) - (r)])
 #define put_cc(cc) put_str(cc_names[cc])

--- a/disassem.h
+++ b/disassem.h
@@ -1,0 +1,9 @@
+#ifndef __DISASSEM_H_
+#define __DISASSEM_H_
+
+#include "z80.h"
+
+int disassemlen(void);
+int disassem(z80info *z80, word start, FILE *fp);
+
+#endif /* __DISASSEM_H_ */

--- a/main.c
+++ b/main.c
@@ -18,6 +18,7 @@
 #include <assert.h>
 
 #include "defs.h"
+#include "bdos.h"
 #include "vt.h"
 
 #if defined macintosh

--- a/main.c
+++ b/main.c
@@ -15,6 +15,7 @@
 #include <errno.h>
 #include <string.h>
 #include <ctype.h>
+#include <assert.h>
 
 #include "defs.h"
 #include "vt.h"
@@ -1035,6 +1036,15 @@ interrupt(int s)
 	signal(s, interrupt);
 }
 
+static void
+intercept(void *ctx, struct z80info *z80)
+{
+    /* Reserved for future use */
+    assert(!ctx);
+
+
+
+}
 
 /*-----------------------------------------------------------------------*\
  |  main  --  set up the global vars & run the z80
@@ -1095,6 +1105,8 @@ main(int argc, const char *argv[])
 
 	if (z80 == NULL)
 		return -1;
+
+    z80_set_interceptor(z80, NULL, intercept);
 
 	initterm();
 

--- a/main.c
+++ b/main.c
@@ -18,8 +18,11 @@
 #include <assert.h>
 
 #include "defs.h"
+#include "vm.h"
+#include "bios.h"
 #include "bdos.h"
 #include "vt.h"
+#include "disassem.h"
 
 #if defined macintosh
 #	include <Types.h>

--- a/main.c
+++ b/main.c
@@ -111,7 +111,7 @@ void vm_destroy(vm *obj)
 }
 
 
-char *jgets(char *s, int len, FILE *f)
+static char *jgets(char *s, int len, FILE *f)
 {
 	char *rtn = fgets(s, len, f);
 	if (rtn)

--- a/main.c
+++ b/main.c
@@ -209,6 +209,7 @@ static void
 command(vm *obj, z80info *z80)
 {
 	unsigned int i, j, t, e;
+	int c;
 	char str[256], *s;
 	FILE *fp;
 	static word pe = 0;
@@ -315,11 +316,13 @@ loop:	/* "infinite" loop */
 
 		for (i = 0; i <= 8; i++)
 		{
-			printf("  %.4X:   ", pe);
-
+			printf("  %.4X: ", pe);
 			for (j = 0; j <= 0xF; j++)
-				printf("%.2X  ", z80->mem[pe++]);
-
+				printf("%.2X ", z80->mem[pe++]);
+			for (j = 0; j <= 0xF; j++) {
+				c = z80->mem[t + (i << 4) + j];
+				putchar(isprint(c) ? c : '.');
+			}
 			printf("\n");
 		}
 

--- a/main.c
+++ b/main.c
@@ -44,32 +44,67 @@
 
 #define INTR_CHAR	31	/* control-underscore */
 
-extern int errno;
+struct vm_s {
+	bdos *bd;
+	bios *bios;
+	int nobdos;
+	int strace;
+	int bdos_return;
 
-int nobdos;
-int strace;
-int bdos_return = -1;
+    /* these are for the I/O, CP/M, and outside needs */
+    boolean trace;		/* trace mode off/on */
+    boolean step;		/* step-trace mode off/on */
+    int sig;		/* caught a signal */
+    int syscall;	/* CP/M syscall to be done */
+    int biosfn;		/* BIOS function be done */
 
-/* globally visible vars */
-static FILE *logfile = NULL;
-
+    int have_term;   /* FALSE if terminal initialization failed */
 
 #ifndef _WIN32
 #  if defined UNIX || defined BeBox
 #    ifdef POSIX_TTY
 #	   define termio termios
 #    endif
-static struct termio rawterm, oldterm;	/* for raw terminal I/O */
+    struct termio rawterm, oldterm;	/* for raw terminal I/O */
 #  endif
 #endif
 
+    FILE *logfile;
+};
+
+extern int errno;
+
+static void dumptrace(vm *obj, z80info *z80);
+
+vm *vm_new()
+{
+	vm *obj;
+	obj = calloc(1, sizeof(vm));
+	obj->bios = bios_new(obj);
+	obj->bd = bdos_new(obj, obj->bios);
+	obj->bdos_return = -1;
+
+	/* initialize the other misc stuff */
+	obj->trace = FALSE;
+	obj->step = FALSE;
+	obj->sig = 0;
+	obj->syscall = FALSE;
+
 #ifdef _WIN32
-static int have_term = 0;   /* no terminal in Win32 */
+	obj->have_term = 0;   /* no terminal in Win32 */
 #else
-static int have_term = 1;   /* FALSE if terminal initialization failed */
+	obj->have_term = 1;   /* FALSE if terminal initialization failed */
 #endif
 
-static void dumptrace(z80info *z80);
+	return obj;
+}
+
+void vm_destroy(vm *obj)
+{
+	bdos_destroy(obj->bd);
+	bios_destroy(obj->bios);
+	free(obj);
+}
 
 
 char *jgets(char *s, int len, FILE *f)
@@ -89,14 +124,13 @@ char *jgets(char *s, int len, FILE *f)
 \*-----------------------------------------------------------------------*/
 
 void
-resetterm(void)
+vm_resetterm(vm *obj)
 {
 #ifndef _WIN32
-    if (have_term)
-		tcsetattr(fileno(stdin), TCSADRAIN, &oldterm);
+    if (obj->have_term)
+		tcsetattr(fileno(stdin), TCSADRAIN, &obj->oldterm);
 #endif
 }
-
 
 
 /*-----------------------------------------------------------------------*\
@@ -104,11 +138,11 @@ resetterm(void)
 \*-----------------------------------------------------------------------*/
 
 void
-setterm(void)
+vm_setterm(vm *obj)
 {
 #ifndef _WIN32
-    if (have_term)
-		tcsetattr(fileno(stdin), TCSADRAIN, &rawterm);
+    if (obj->have_term)
+		tcsetattr(fileno(stdin), TCSADRAIN, &obj->rawterm);
 #endif
 }
 
@@ -120,25 +154,25 @@ setterm(void)
 \*-----------------------------------------------------------------------*/
 
 static void
-initterm(void)
+initterm(vm *obj)
 {
 #ifdef _WIN32
 		fprintf(stderr, "Sorry, terminal not found, using cooked mode.\n");
-		have_term = 0;
+		obj->have_term = 0;
 #else
-	if (tcgetattr(fileno(stdin), &oldterm))
+	if (tcgetattr(fileno(stdin), &obj->oldterm))
 	{
 		fprintf(stderr, "Sorry, terminal not found, using cooked mode.\n");
-		have_term = 0;
+		obj->have_term = 0;
 	}
         else {
-	rawterm = oldterm;
-	rawterm.c_iflag &= ~(ICRNL | IXON | IXOFF | INLCR | ICRNL);
-	rawterm.c_lflag &= ~(ICANON | ECHO);
-	rawterm.c_cc[VSUSP] = -1;
-	rawterm.c_cc[VQUIT] = -1;
-	rawterm.c_cc[VERASE] = -1;
-	rawterm.c_cc[VKILL] = -1;
+	obj->rawterm = obj->oldterm;
+	obj->rawterm.c_iflag &= ~(ICRNL | IXON | IXOFF | INLCR | ICRNL);
+	obj->rawterm.c_lflag &= ~(ICANON | ECHO);
+	obj->rawterm.c_cc[VSUSP] = -1;
+	obj->rawterm.c_cc[VQUIT] = -1;
+	obj->rawterm.c_cc[VERASE] = -1;
+	obj->rawterm.c_cc[VKILL] = -1;
   }
 	/* tcsetattr(fileno(stdin), TCSADRAIN, &rawterm); */
 
@@ -162,16 +196,13 @@ initterm(void)
 #endif
 }
 
-
-
-
 /*-----------------------------------------------------------------------*\
  |  command  --  called when user-level commands are needed by the z80
  |  for some reason or another
 \*-----------------------------------------------------------------------*/
 
 static void
-command(z80info *z80)
+command(vm *obj, z80info *z80)
 {
 	unsigned int i, j, t, e;
 	char str[256], *s;
@@ -179,7 +210,7 @@ command(z80info *z80)
 	static word pe = 0;
 	static word po = 0;
 
-	resetterm();
+	vm_resetterm(obj);
 	printf("\n");
 
 loop:	/* "infinite" loop */
@@ -206,10 +237,10 @@ loop:	/* "infinite" loop */
 		break;
 
 	case 'o':
-		if (logfile != NULL)
+		if (obj->logfile != NULL)
 		{
-			fclose(logfile);
-			logfile = NULL;
+			fclose(obj->logfile);
+			obj->logfile = NULL;
 			printf("    Logging off.\n");
 		}
 		else
@@ -223,9 +254,9 @@ loop:	/* "infinite" loop */
 			if (*s == '\0')
 				break;
 
-			logfile = fopen(s, "w");
+			obj->logfile = fopen(s, "w");
 
-			if (logfile == NULL)
+			if (obj->logfile == NULL)
 				printf("Cannot open logfile!\n");
 			else
 				printf("    Logging on.\n");
@@ -235,13 +266,13 @@ loop:	/* "infinite" loop */
 
 	case '!':				/* fork a shell */
 		system("exec ${SHELL:-/bin/sh}");
-		initterm();
+		initterm(obj);
 		printf("\n");
 		break;
 
 	case 'q':				/* quit */
-		if (logfile != NULL)
-			fclose(logfile);
+		if (obj->logfile != NULL)
+			fclose(obj->logfile);
 
 		exit(0);
 		break;
@@ -251,24 +282,24 @@ loop:	/* "infinite" loop */
 		break;
 
 	case 'b':				/* boot cp/m */
-		setterm();
-		sysreset(z80);
+		vm_setterm(obj);
+		bios_sysreset(obj->bios, z80);
 		return;
 		break;
 
 	case 't':				/* toggle trace mode */
-		z80->trace = !z80->trace;
-		printf("    Trace %s\n", z80->trace ? "on" : "off");
+		obj->trace = !obj->trace;
+		printf("    Trace %s\n", obj->trace ? "on" : "off");
 		break;
 
 	case 's':				/* toggle step-trace mode */
-		z80->step = !z80->step;
-		printf("    Step-trace %s\n", z80->step ? "on" : "off");
-		printf("    Trace %s\n", z80->trace ? "on" : "off");
+		obj->step = !obj->step;
+		printf("    Step-trace %s\n", obj->step ? "on" : "off");
+		printf("    Trace %s\n", obj->trace ? "on" : "off");
 		break;
 
 	case 'd':					/* dump registers */
-		dumptrace(z80);
+		dumptrace(obj, z80);
 		break;
 
 	case 'e':					/* examine memory */
@@ -483,7 +514,7 @@ loop:	/* "infinite" loop */
 		printf("    File-name: ");
 		jgets(str, sizeof(str), stdin);
 
-		if (!loadfile(z80, str))
+		if (!vm_loadfile(z80, str))
 			fprintf(stderr, "Cannot load file %s!\r\n", str);
 
 		break;
@@ -491,7 +522,7 @@ loop:	/* "infinite" loop */
 	case '\0':			/* carriage-return */
 	case '\r':
 	case '\n':
-		if (z80->trace && z80->step)
+		if (obj->trace && obj->step)
 			goto cont;
 
 		break;
@@ -499,9 +530,9 @@ loop:	/* "infinite" loop */
 	case 'c':			/* continue z80 execution */
 	case 'g':
 	cont:
-		setterm();
+		vm_setterm(obj);
 
-		if (z80->trace)
+		if (obj->trace)
 		{
 			z80->event = TRUE;
 			z80->halt = TRUE;
@@ -528,7 +559,7 @@ loop:	/* "infinite" loop */
 \*-----------------------------------------------------------------------*/
 
 static void
-dumptrace(z80info *z80)
+dumptrace(vm *obj, z80info *z80)
 {
 	printf("a%.2X f%.2X bc%.4X de%.4X hl%.4X ",
 			A, F, BC, DE, HL);
@@ -537,14 +568,14 @@ dumptrace(z80info *z80)
 	disassem(z80, PC, stdout);
 	printf("\r\n");
 
-	if (logfile)
+	if (obj->logfile)
 	{
-		fprintf(logfile, "a%.2X f%.2X bc%.4X de%.4X hl%.4X ",
+		fprintf(obj->logfile, "a%.2X f%.2X bc%.4X de%.4X hl%.4X ",
 				A, F, BC, DE, HL);
-		fprintf(logfile, "ix%.4X iy%.4X sp%.4X pc%.4X:%.2X  ",
+		fprintf(obj->logfile, "ix%.4X iy%.4X sp%.4X pc%.4X:%.2X  ",
 				IX, IY, SP, PC, z80->mem[PC]);
-		disassem(z80, PC, logfile);
-		fprintf(logfile, "\r\n");
+		disassem(z80, PC, obj->logfile);
+		fprintf(obj->logfile, "\r\n");
 	}
 }
 
@@ -711,7 +742,7 @@ suffix(char *str, const char *suff)
 
 
 boolean
-loadfile(z80info *z80, const char *fname)
+vm_loadfile(z80info *z80, const char *fname)
 {
 	char buf[200];
 	FILE *fp;
@@ -757,7 +788,7 @@ loadfile(z80info *z80, const char *fname)
    and we must wait for some to occur */
 
 boolean
-input(z80info *z80, byte haddr, byte laddr, byte *val)
+vm_input(vm *obj, z80info *z80, byte haddr, byte laddr, byte *val)
 {
 	unsigned int data;
 
@@ -785,7 +816,7 @@ input(z80info *z80, byte haddr, byte laddr, byte *val)
 			if ((data == '.' && (ev.modifiers & cmdKey)) ||
 					data == INTR_CHAR)
 			{
-				command(z80);
+				command(obj, z80);
 				goto again;
 			}
 			else if (data == 'q' && (ev.modifiers & cmdKey))
@@ -796,7 +827,7 @@ input(z80info *z80, byte haddr, byte laddr, byte *val)
 
 			while (data == INTR_CHAR)
 			{
-				command(z80);
+				command(obj, z80);
 				data = getkey();
 			}
 #else	/* TCGETA */
@@ -807,7 +838,7 @@ input(z80info *z80, byte haddr, byte laddr, byte *val)
 			while ((data > 0x7f && errno == EINTR) ||
 					data == INTR_CHAR)
 			{
-				command(z80);
+				command(obj, z80);
 				data = kget(0);
 				/* data = getchar(); */
 			}
@@ -841,11 +872,11 @@ input(z80info *z80, byte haddr, byte laddr, byte *val)
 
 	/* default - prompt the user for an input byte */
 	default:
-		resetterm();
+		vm_resetterm(obj);
 		printf("INPUT : addr = %X%X    DATA = ", haddr, laddr);
 		fflush(stdout);
 		scanf("%x", &data);
-		setterm();
+		vm_setterm(obj);
 		*val = data;
 		break;
 	}
@@ -859,7 +890,7 @@ input(z80info *z80, byte haddr, byte laddr, byte *val)
 \*-----------------------------------------------------------------------*/
 
 void
-output(z80info *z80, byte haddr, byte laddr, byte data)
+vm_output(vm *obj, z80info *z80, byte haddr, byte laddr, byte data)
 {
 	if (laddr == 0xFF) {
 		/* BIOS call - interrupt the z80 before the next instruction
@@ -867,30 +898,29 @@ output(z80info *z80, byte haddr, byte laddr, byte data)
 		   otherwise we would do it right here */
 		z80->event = TRUE;
 		z80->halt = TRUE;
-		z80->syscall = TRUE;
-		z80->biosfn = data;
+		obj->syscall = TRUE;
+		obj->biosfn = data;
 
-		if (z80->trace)
+		if (obj->trace)
 		{
-			printf("BIOS call %d\r\n", z80->biosfn);
+			printf("BIOS call %d\r\n", obj->biosfn);
 
-			if (logfile)
-				fprintf(logfile, "BIOS call %d\r\n",
-					z80->biosfn);
+			if (obj->logfile)
+				fprintf(obj->logfile, "BIOS call %d\r\n",
+					obj->biosfn);
 		}
 	} else if (laddr == 0) {
 		/* output a character to the screen */
 		/* putchar(data); */
 		vt52(data);
 
-		if (logfile != NULL)
-			putc(data, logfile);
+		if (obj->logfile != NULL)
+			putc(data, obj->logfile);
 	} else {
 		/* dump the data for our user */
 		printf("OUTPUT: addr = %X%X  DATA = %X\r\n", haddr, laddr,data);
 	}
 }
-
 
 
 /*-----------------------------------------------------------------------*\
@@ -899,43 +929,43 @@ output(z80info *z80, byte haddr, byte laddr, byte data)
 \*-----------------------------------------------------------------------*/
 
 void
-haltcpu(z80info *z80)
+vm_haltcpu(vm *obj, z80info *z80)
 {
 	z80->halt = FALSE;
 
 	/* we were interrupted by a Unix signal */
-	if (z80->sig)
+	if (obj->sig)
 	{
-		if (z80->sig != SIGINT)
-			printf("\r\nCaught signal %d.\r\n", z80->sig);
+		if (obj->sig != SIGINT)
+			printf("\r\nCaught signal %d.\r\n", obj->sig);
 
-		z80->sig = 0;
-		command(z80);
+		obj->sig = 0;
+		command(obj, z80);
 		return;
 	}
 
 	/* we are tracing execution of the z80 */
-	if (z80->trace)
+	if (obj->trace)
 	{
 		/* re-enable tracing */
 		z80->event = TRUE;
 		z80->halt = TRUE;
-		dumptrace(z80);
+		dumptrace(obj, z80);
 
-		if (z80->step)
-			command(z80);
+		if (obj->step)
+			command(obj, z80);
 	}
 
 	/* a CP/M syscall - done here so tracing still works */
-	if (z80->syscall)
+	if (obj->syscall)
 	{
-		z80->syscall = FALSE;
-		bios(z80, z80->biosfn);
+		obj->syscall = FALSE;
+		bios_call(obj->bios, z80, obj->biosfn);
 	}
 }
 
 word
-read_mem(z80info *z80, word addr)
+vm_read_mem(vm *obj, z80info *z80, word addr)
 {
 #ifdef MEM_BREAK
 	if (z80->membrk[addr] & M_BREAKPOINT)
@@ -956,15 +986,15 @@ read_mem(z80info *z80, word addr)
 		/* fake some sort of I/O here and return its value */
 	}
 
-	dumptrace(z80);
-	command(z80);
+	dumptrace(obj, z80);
+	command(obj, z80);
 #endif	/* MEM_BREAK */
 
 	return z80->mem[addr];
 }
 
 word
-write_mem(z80info *z80, word addr, byte val)
+vm_write_mem(vm *obj, z80info *z80, word addr, byte val)
 {
 #ifdef MEM_BREAK
 	if (z80->membrk[addr] & M_BREAKPOINT)
@@ -986,22 +1016,24 @@ write_mem(z80info *z80, word addr, byte val)
 		/* then return */
 	}
 
-	dumptrace(z80);
-	command(z80);
+	dumptrace(obj, z80);
+	command(obj, z80);
 #endif	/* MEM_BREAK */
 
 	return z80->mem[addr] = val;
 }
 
 void
-undefinstr(z80info *z80, byte instr)
+vm_undefinstr(vm *obj, z80info *z80, byte instr)
 {
 	printf("\r\nIllegal instruction 0x%.2X at PC=0x%.4X\r\n",
 		instr, PC - 1);
-	command(z80);
+	command(obj, z80);
 }
 
-
+/* this is needed by interrupt(), quit() and main() */
+static z80info *z80 = NULL;
+static vm *obj = NULL;
 
 /*-----------------------------------------------------------------------*\
  |  quit -- terminate this program after cleaning up -- this it is       |
@@ -1012,14 +1044,9 @@ static void
 quit(int sig)
 {
 	printf("\r\nCaught signal %d.\r\n", sig);
-	resetterm();
+	vm_resetterm(obj);
 	exit(2);
 }
-
-
-/* this is needed by both interrupt() and main() */
-static z80info *z80 = NULL;
-
 
 /*-----------------------------------------------------------------------*\
  |  interrupt  --  this is called when we get a usable signal from Unix
@@ -1033,7 +1060,7 @@ interrupt(int s)
 	{
 	    z80->event = TRUE;
 	    z80->halt = TRUE;
-	    z80->sig = s;
+	    obj->sig = s;
 	}
 
 	signal(s, interrupt);
@@ -1047,38 +1074,37 @@ static void
 intercept(void *ctx, struct z80info *z80)
 {
     int i;
-    bdos *bd;
-
-    bd = (bdos *)ctx;
+    vm *obj;
+    obj = ctx;
 
 	/* Trace system calls */
-	if (strace && PC == BDOS_HOOK)
+	if (obj->strace && PC == BDOS_HOOK)
 	{
 	        printf("\r\nbdos call %d %s (AF=%04x BC=%04x DE=%04x HL =%04x SP=%04x STACK=", C, bdos_decode(C), AF, BC, DE, HL, SP);
 		for (i = 0; i < 8; ++i)
 		    printf(" %4x", z80->mem[SP + 2*i]
 			   + 256 * z80->mem[SP + 2*i + 1]);
 		printf(")\r\n");
-		bdos_return = SP + 2;
+		obj->bdos_return = SP + 2;
 		if (bdos_fcb(C))
 			bdos_fcb_dump(z80);
 	}
 
-	if (SP == bdos_return)
+	if (SP == obj->bdos_return)
 	{
 	        printf("\r\nbdos return %d %s (AF=%04x BC=%04x DE=%04x HL =%04x SP=%04x STACK=", C, bdos_decode(C), AF, BC, DE, HL, SP);
 		for (i = 0; i < 8; ++i)
 		    printf(" %4x", z80->mem[SP + 2*i]
 			   + 256 * z80->mem[SP + 2*i + 1]);
 		printf(")\r\n");
-		bdos_return = -1;
+		obj->bdos_return = -1;
 		if (bdos_fcb(C))
 			bdos_fcb_dump(z80);
 	}
 
-	if (!nobdos && PC == BDOS_HOOK)
+	if (!obj->nobdos && PC == BDOS_HOOK)
 	{
-		bdos_check_hook(bd, z80);
+		bdos_check_hook(obj->bd, z80);
 	}
 }
 
@@ -1113,24 +1139,23 @@ main(int argc, const char *argv[])
 	int x;
 	char cmd[256];
 	int help = 0;
-	bdos *bd;
 
 	cmd[0] = 0;
 
-	bd = bdos_new();
+	obj = vm_new();
 
 	for (x = 1; x < argc; ++x) {
 		if (argv[x][0] == '-' && argv[x][1] == '-') {
 			if (!strcmp(argv[x], "--help")) {
 				help = 1;
 			} else if (!strcmp(argv[x], "--exec")) {
-				bdos_set_exec(bd, 1);
+				bdos_set_exec(obj->bd, 1);
 			} else if (!strcmp(argv[x], "--nobdos")) {
-				nobdos = 1;
+				obj->nobdos = 1;
 			} else if (!strcmp(argv[x], "--trace_bdos")) {
-				bdos_set_trace_bdos(bd, 1);
+				bdos_set_trace_bdos(obj->bd, 1);
 			} else if (!strcmp(argv[x], "--strace")) {
-				strace = 1;
+				obj->strace = 1;
 			} else {
 				fprintf(stderr, "Unknown option %s\n", argv[x]);
 				exit(1);
@@ -1158,22 +1183,22 @@ main(int argc, const char *argv[])
 	}
 
 	if (cmd[0])
-		bdos_set_cmd(bd, cmd);
+		bdos_set_cmd(obj->bd, cmd);
 
-	z80 = z80_new();
-    z80_set_interceptor(z80, bd, intercept);
+	z80 = z80_new(obj);
+    z80_set_interceptor(z80, obj, intercept);
     if (!z80) {
 	z80_destroy(z80);
-	bdos_destroy(bd);
+	vm_destroy(obj);
 	return -1;
     }
 
-	initterm();
+	initterm(obj);
 
 	/* set up the signals */
 	setsigs();
-	setterm();
-	sysreset(z80);
+	vm_setterm(obj);
+	bios_sysreset(obj->bios, z80);
 
 	while (1)
 	{
@@ -1185,6 +1210,6 @@ main(int argc, const char *argv[])
 	}
 
 	z80_destroy(z80);
-	bdos_destroy(bd);
+	vm_destroy(obj);
 	return 0;
 }

--- a/main.c
+++ b/main.c
@@ -1091,7 +1091,7 @@ main(int argc, const char *argv[])
 		stuff_cmd = cmd;
 	}
 
-	z80 = new_z80info();
+	z80 = z80_new();
 
 	if (z80 == NULL)
 		return -1;
@@ -1122,6 +1122,6 @@ main(int argc, const char *argv[])
 		EventRecord ev;
 		WaitNextEvent(0, &ev, 0, nil);
 #endif
-		z80_emulator(z80, 100000);
+		z80_run(z80, 100000);
 	}
 }

--- a/vm.h
+++ b/vm.h
@@ -3,9 +3,10 @@
 
 #include "z80.h"
 #include "defs.h"
-#include "bios.h"
 
 /* main.c contains vm class */
+
+typedef struct vm_s vm;
 
 vm *vm_new();
 void vm_resetterm(vm *obj);

--- a/vm.h
+++ b/vm.h
@@ -1,0 +1,22 @@
+#ifndef __VM_H_
+#define __VM_H_
+
+#include "z80.h"
+#include "defs.h"
+#include "bios.h"
+
+/* main.c contains vm class */
+
+vm *vm_new();
+void vm_resetterm(vm *obj);
+void vm_setterm(vm *obj);
+boolean vm_input(vm *obj, z80info *z80, byte haddr, byte laddr, byte *val);
+void vm_output(vm *obj, z80info *z80, byte haddr, byte laddr, byte data);
+void vm_haltcpu(vm *obj, z80info *z80);
+word vm_read_mem(vm *obj, z80info *z80, word addr);
+word vm_write_mem(vm *obj, z80info *z80, word addr, byte val);
+void vm_undefinstr(vm *obj, z80info *z80, byte instr);
+boolean vm_loadfile(z80info *z80, const char *fname);
+void vm_destroy(vm *obj);
+
+#endif /* __VM_H_ */

--- a/vt.h
+++ b/vt.h
@@ -1,3 +1,5 @@
+#ifndef __VT_H_
+#define __VT_H_
 
 /* Return true if input character available */
 int constat();
@@ -11,3 +13,4 @@ int kget(int w);
 /* Write character to terminal */
 void vt52(int c);
 
+#endif /* __DEFS_H_ */

--- a/z80.c
+++ b/z80.c
@@ -241,8 +241,6 @@ z80_run(z80info *z80, int count)
 	word tt, tt2, hh, vv, *rr;
 	longword ttt;
 	int i, j, h, n, s;
-	z80info *obj;
-	obj = z80;
 
 	/* main loop  --  all "goto"s eventually end up here */
 infloop:

--- a/z80.c
+++ b/z80.c
@@ -10,12 +10,7 @@
 #include <string.h>
 #include "defs.h"
 
-int nobdos;
-int strace;
-int bdos_return = -1;
-
 /* All the following macros assume access to a parameter named "z80" */
-
 
 /* entry in "REGPAIRXY[]" to get to the IX or IY registers */
 #define XYPAIR 2
@@ -962,44 +957,11 @@ contsw:
 		break;
 	}					/* end of main "switch" */
 
-
 	/** Notify the interceptor if any */
 	if (z80->intercept)
 	    z80->intercept(z80->intercept_ctx, z80);
 
-	/* Trace system calls */
-	if (strace && PC == BDOS_HOOK)
-	{
-	        printf("\r\nbdos call %d %s (AF=%04x BC=%04x DE=%04x HL =%04x SP=%04x STACK=", C, bdos_decode(C), AF, BC, DE, HL, SP);
-		for (i = 0; i < 8; ++i)
-		    printf(" %4x", z80->mem[SP + 2*i]
-			   + 256 * z80->mem[SP + 2*i + 1]);
-		printf(")\r\n");
-		bdos_return = SP + 2;
-		if (bdos_fcb(C))
-			bdos_fcb_dump(z80);
-	}
-
-	if (SP == bdos_return)
-	{
-	        printf("\r\nbdos return %d %s (AF=%04x BC=%04x DE=%04x HL =%04x SP=%04x STACK=", C, bdos_decode(C), AF, BC, DE, HL, SP);
-		for (i = 0; i < 8; ++i)
-		    printf(" %4x", z80->mem[SP + 2*i]
-			   + 256 * z80->mem[SP + 2*i + 1]);
-		printf(")\r\n");
-		bdos_return = -1;
-		if (bdos_fcb(C))
-			bdos_fcb_dump(z80);
-	}
-
-	if (!nobdos && PC == BDOS_HOOK)
-	{
-		check_BDOS_hook(z80);
-	}
-
 	goto infloop;
-
-
 
 	/* bit-twiddling instructions */
 bitinstr:

--- a/z80.c
+++ b/z80.c
@@ -964,10 +964,8 @@ contsw:
 
 
 	/** Notify the interceptor if any */
-/*
 	if (z80->intercept)
-	    z80->intercept(NULL, z80);
-*/
+	    z80->intercept(z80->intercept_ctx, z80);
 
 	/* Trace system calls */
 	if (strace && PC == BDOS_HOOK)
@@ -2059,7 +2057,7 @@ z80_new(void)
 }
 
 void
-set_interceptor(z80info *z80, void *intercept_ctx,
+z80_set_interceptor(z80info *z80, void *intercept_ctx,
         void (*intercept)(void *, struct z80info *))
 {
     z80->intercept_ctx = intercept_ctx;

--- a/z80.c
+++ b/z80.c
@@ -1974,12 +1974,6 @@ init_z80info(z80info *z80, vm *vm)
 	REGIR[0] = &I;
 	REGIR[1] = &R;
 
-	/* initialize the CP/M BIOS data */
-	z80->drive = 0;
-	z80->dma = 0x80;
-	z80->track = 0;
-	z80->sector = 1;
-
 	z80->vm = vm;
 
 	/* initialize the global parity array if necessary */

--- a/z80.c
+++ b/z80.c
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "defs.h"
+#include "vm.h"
 
 /* All the following macros assume access to a parameter named "z80" */
 

--- a/z80.c
+++ b/z80.c
@@ -179,6 +179,8 @@ z80_run(z80info *z80, int count)
 	word tt, tt2, hh, vv, *rr;
 	longword ttt;
 	int i, j, h, n, s;
+	z80info *obj;
+	obj = z80;
 
 	/* main loop  --  all "goto"s eventually end up here */
 infloop:
@@ -194,7 +196,7 @@ infloop:
 
 		/* HALT execution if desired - this is for tracing & such */
 		if (HALT)
-			haltcpu(z80);
+			vm_haltcpu(z80->vm, z80);
 
 		/* "i" is used to see if we need to get the next opcode or not*/
 		i = TRUE;
@@ -667,11 +669,11 @@ contsw:
 	case 0x27:					/* daa */
 		i = 0;
 		t = 0x00;
-		if (F & CARRY || A > 0x99) {
+		if ((F & CARRY) || A > 0x99) {
 			t |= 0x60;
 			i = 1;
 		}
-		if (F & HALF || (A & MASK4) > 9)
+		if ((F & HALF) || (A & MASK4) > 9)
 			t |= 0x06;
 		arith8(t, 0, F & NEGATIVE);
 		setflag(CARRY, i);
@@ -940,20 +942,20 @@ contsw:
 	/* input & output group */
 
 	case 0xDB:					/* in a,n */
-		if (!input(z80, A, MEM(PC), &t1))
+		if (!vm_input(z80->vm, z80, A, MEM(PC), &t1))
 			return FALSE;
 
 		A = t1;
 		PC++;
 		break;
 	case 0xD3:					/* out a,n */
-		output(z80, A, MEM(PC), A);
+		vm_output(z80->vm, z80, A, MEM(PC), A);
 		PC++;
 		break;
 
 
 	default: 
-		undefinstr(z80, t);
+		vm_undefinstr(z80->vm, z80, t);
 		break;
 	}					/* end of main "switch" */
 
@@ -1321,7 +1323,7 @@ bitinstr:
 		break;
 
 	default: 
-		undefinstr(z80, t);
+		vm_undefinstr(z80->vm, z80, t);
 		break;
 	}	/* end of "bitinstr" "switch" */
 
@@ -1516,7 +1518,7 @@ ireginstr:
 
 
 	default:
-		undefinstr(z80, t);
+		vm_undefinstr(z80->vm, z80, t);
 		break;
 	}	/* end of "ireginstr" "switch" */
 
@@ -1736,7 +1738,7 @@ extinstr:
 	case 0x68:					/* in l,c */
 	case 0x70:					/* in ?,c */
 	case 0x78:					/* in a,c */
-		if (!input(z80, B, C, &t1))
+		if (!vm_input(z80->vm, z80, B, C, &t1))
 			return FALSE;
 
 		v = *REG[(t >> 3) & MASK3] = t1;
@@ -1754,14 +1756,14 @@ extinstr:
 	case 0x69:					/* out l,c */
 	case 0x79:					/* out a,c */
 	case 0x41:					/* out b,c */
-		output(z80, B, C, *REG[(t >> 3) & MASK3]);
+		vm_output(z80->vm, z80, B, C, *REG[(t >> 3) & MASK3]);
 		break;
 
 	case 0xA2:					/* ini */
 	case 0xAA:					/* ind */
 	case 0xB2:					/* inir */
 	case 0xBA:					/* indr */
-		if (!input(z80, B, C, &t1))
+		if (!vm_input(z80->vm, z80, B, C, &t1))
 			return FALSE;
 
 		SETMEM(HL, t1);
@@ -1784,7 +1786,7 @@ extinstr:
 	case 0xB3:					/* otir */
 	case 0xBB:					/* otdr */
 		resetflag(ZERO, --B);
-		output(z80, B, C, MEM(HL));
+		vm_output(z80->vm, z80, B, C, MEM(HL));
 
 		if (t & BIT3)
 			HL--;
@@ -1800,7 +1802,7 @@ extinstr:
 
 
 	default:
-		undefinstr(z80, t);
+		vm_undefinstr(z80->vm, z80, t);
 		break;
 	}	/* end of "extinstr" "switch" */
 
@@ -1911,7 +1913,7 @@ iregbitinstr:
 
 
 	default: 
-		undefinstr(z80, t);
+		vm_undefinstr(z80->vm, z80, t);
 		break;
 	}	/* end of "iregbitinstr" "switch" */
 
@@ -1924,7 +1926,7 @@ iregbitinstr:
 
 /* initialize the z80 struct with sane stuff */
 static z80info *
-init_z80info(z80info *z80)
+init_z80info(z80info *z80, vm *vm)
 {
 	int i;
 
@@ -1971,17 +1973,13 @@ init_z80info(z80info *z80)
 	REGIR[0] = &I;
 	REGIR[1] = &R;
 
-	/* initialize the other misc stuff */
-	z80->trace = FALSE;
-	z80->step = FALSE;
-	z80->sig = 0;
-	z80->syscall = FALSE;
-
 	/* initialize the CP/M BIOS data */
 	z80->drive = 0;
 	z80->dma = 0x80;
 	z80->track = 0;
 	z80->sector = 1;
+
+	z80->vm = vm;
 
 	/* initialize the global parity array if necessary */
 	if (!parity_inited)
@@ -2005,7 +2003,7 @@ init_z80info(z80info *z80)
 }
 
 z80info *
-z80_new(void)
+z80_new(vm * vm)
 {
 	z80info *z80 = malloc(sizeof *z80);
 
@@ -2015,7 +2013,7 @@ z80_new(void)
 		return NULL;
 	}
 
-	return init_z80info(z80);
+	return init_z80info(z80, vm);
 }
 
 void

--- a/z80.c
+++ b/z80.c
@@ -962,6 +962,13 @@ contsw:
 		break;
 	}					/* end of main "switch" */
 
+
+	/** Notify the interceptor if any */
+/*
+	if (z80->intercept)
+	    z80->intercept(NULL, z80);
+*/
+
 	/* Trace system calls */
 	if (strace && PC == BDOS_HOOK)
 	{
@@ -1956,7 +1963,7 @@ iregbitinstr:
 
 
 /* initialize the z80 struct with sane stuff */
-z80info *
+static z80info *
 init_z80info(z80info *z80)
 {
 	int i;
@@ -2049,6 +2056,14 @@ z80_new(void)
 	}
 
 	return init_z80info(z80);
+}
+
+void
+set_interceptor(z80info *z80, void *intercept_ctx,
+        void (*intercept)(void *, struct z80info *))
+{
+    z80->intercept_ctx = intercept_ctx;
+    z80->intercept = intercept;
 }
 
 void

--- a/z80.c
+++ b/z80.c
@@ -178,7 +178,7 @@ static boolean parity_inited = FALSE;
 \*-----------------------------------------------------------------------*/
 
 boolean
-z80_emulator(z80info *z80, int count)
+z80_run(z80info *z80, int count)
 {
 	byte t = 0, t1, t2, cy, v, *r = NULL;
 	word tt, tt2, hh, vv, *rr;
@@ -2038,17 +2038,9 @@ init_z80info(z80info *z80)
 }
 
 z80info *
-destroy_z80info(z80info *z80)
+z80_new(void)
 {
-	/* free the mem array if allocated above */
-	/* free(z80->mem); */
-	return z80;
-}
-
-z80info *
-new_z80info(void)
-{
-	z80info *z80 = (z80info*)malloc(sizeof *z80);
+	z80info *z80 = malloc(sizeof *z80);
 
 	if (z80 == NULL)
 	{
@@ -2060,11 +2052,7 @@ new_z80info(void)
 }
 
 void
-delete_z80info(z80info *z80)
+z80_destroy(z80info *z80)
 {
-	if (z80 == NULL)
-		return;
-
-	destroy_z80info(z80);
 	free(z80);
 }

--- a/z80.h
+++ b/z80.h
@@ -1,0 +1,200 @@
+#ifndef __Z80_H_
+#define __Z80_H_
+
+#include "defs.h"
+
+/* handy bit definitions - bit fields are not used as they are generally
+   much slower than the equivalent logical masking operations */
+
+#define BIT16  0x10000L
+#define BIT15   0x8000
+#define BIT14   0x4000
+#define BIT13   0x2000
+#define BIT12   0x1000
+#define BIT11   0x0800
+#define BIT10   0x0400
+#define BIT9    0x0200
+#define BIT8    0x0100
+#define BIT7    0x0080
+#define BIT6    0x0040
+#define BIT5    0x0020
+#define BIT4    0x0010
+#define BIT3    0x0008
+#define BIT2    0x0004
+#define BIT1    0x0002
+#define BIT0    0x0001
+
+/* handy masks to get a particular number of bits out */
+
+#define MASK1   0x01
+#define MASK2   0x03
+#define MASK3   0x07
+#define MASK4   0x0F
+#define MASK5   0x1F
+#define MASK6   0x3F
+#define MASK7   0x7F
+#define MASK8   0xFF
+#define MASK12  0xFFF
+
+#define MASKU4  0xF0
+#define MASK16  0xFFFF
+
+
+/* z80 flag register definitions */
+
+#define SIGN      0x80
+#define ZERO      0x40
+#define HALF      0x10
+#define PARITY    0x04
+#define OVERFLOW  PARITY
+#define NEGATIVE  0x02
+#define CARRY     0x01
+
+
+/* z80 interrupt types - used to set the intr struct var */
+
+#define INTRMASK	0xF00
+#define INT_FLAG	0x100
+#define NM_FLAG		0x200
+#define RESET_FLAG	0x400
+
+
+/* max number of the BIOS drive tables */
+#define MAXDISCS	16
+
+/* TODO: Move the states irrelevant to the CPU to the respective classes */
+typedef struct z80info
+{
+    boolean event;
+ /* byte regaf[2], regbc[2], regde[2], reghl[2]; */
+    word regaf, regbc, regde, reghl;
+    word regaf2, regbc2, regde2, reghl2;
+    word regsp, regpc, regix, regiy;
+    byte regi, regr;
+    byte iff, iff2, imode;
+    byte reset, nmi, intr, halt;
+
+    /* these point to the addresses of the above registers */
+    byte *reg[8];
+    word *regpairaf[4];
+    word *regpairsp[4];
+    word *regpairxy[4];
+    word *regixy[2];
+    byte *regir[2];
+
+    /* TODO: These belong to the BIOS state */
+    /* these are for the CP/M BIOS */
+    int	drive;
+    word dma;
+    word track;
+    word sector;
+    FILE *drives[MAXDISCS];
+    long drivelen[MAXDISCS];
+
+    /* Private: CPU Interceptor is invoked on each and every loop */
+    void *intercept_ctx;
+    void (*intercept)(void *, struct z80info *);
+
+    /* Virtual Machine pointer */
+    vm *vm;
+
+    /* 64k bytes - may be allocated separately if desired */
+    byte mem[0x10000L];
+
+#ifdef MEM_BREAK
+    /* one for each byte of memory for breaks, memory-mapped I/O, etc */
+    byte membrk[0x10000L];
+    long numbrks;
+#endif
+} z80info;
+
+/* All the following macros assume that a variable named "z80" is
+   available to access the above info.  This is to allow multiple
+   z80s to run without stepping on each other.
+*/
+
+
+/* These macros allow memory-mapped I/O if MEM_BREAK is defined.
+   Because of this, these macros must be very carefully used, and
+   there must not be ANY side-effects, such as increment/decerement
+   in any of the macro args.  Customizations go into read_mem() and
+   write_mem().
+*/
+
+#ifdef MEM_BREAK
+#    define MEM(addr)	\
+		(z80->membrk[(word)(addr)] ?	\
+		vm_read_mem(obj->vm, z80, addr) :	\
+		z80->mem[(word)(addr)])
+#    define SETMEM(addr, val)	\
+		(z80->membrk[(word)(addr)] ?	\
+		vm_write_mem(obj->vm, z80, addr, val) :	\
+		(z80->mem[(word)(addr)] = (byte)(val)))
+
+	/* various flags for "membrk" - others may be added */
+#	define M_BREAKPOINT	0x01		/* breakpoint */
+#	define M_READ_PROTECT	0x02		/* read-protected memory */
+#	define M_WRITE_PROTECT	0x04		/* write-protected memory */
+#	define M_MEM_MAPPED_IO	0x08		/* memory-mapped I/O addr */
+
+#else
+#    define MEM(addr) z80->mem[(word)(addr)]
+#    define SETMEM(addr, val) (z80->mem[(word)(addr)] = (byte)(val))
+#endif
+
+
+/* how to access the z80 registers & register pairs */
+
+#ifdef ENDIAN_LITTLE
+#  define A	((unsigned char *)&z80->regaf)[1]
+#  define F	((unsigned char *)&z80->regaf)[0]
+#  define B	((unsigned char *)&z80->regbc)[1]
+#  define C	((unsigned char *)&z80->regbc)[0]
+#  define D	((unsigned char *)&z80->regde)[1]
+#  define E	((unsigned char *)&z80->regde)[0]
+#  define H	((unsigned char *)&z80->reghl)[1]
+#  define L	((unsigned char *)&z80->reghl)[0]
+#else
+#  define A	((unsigned char *)&z80->regaf)[0]
+#  define F	((unsigned char *)&z80->regaf)[1]
+#  define B	((unsigned char *)&z80->regbc)[0]
+#  define C	((unsigned char *)&z80->regbc)[1]
+#  define D	((unsigned char *)&z80->regde)[0]
+#  define E	((unsigned char *)&z80->regde)[1]
+#  define H	((unsigned char *)&z80->reghl)[0]
+#  define L	((unsigned char *)&z80->reghl)[1]
+#endif
+
+#define I	z80->regi
+#define R	z80->regr
+#define AF	z80->regaf
+#define BC	z80->regbc
+#define DE	z80->regde
+#define HL	z80->reghl
+#define AF2	z80->regaf2
+#define BC2	z80->regbc2
+#define DE2	z80->regde2
+#define HL2	z80->reghl2
+#define SP	z80->regsp
+#define PC	z80->regpc
+#define IX	z80->regix
+#define IY	z80->regiy
+#define IFF	z80->iff
+#define IFF2	z80->iff2
+#define IMODE	z80->imode
+#define RESET	z80->reset
+#define NMI	z80->nmi
+#define INTR	z80->intr
+#define HALT	z80->halt
+
+#define EVENT	z80->event
+
+/* z80.c class */
+
+z80info *z80_new(vm *vm);
+void z80_set_interceptor(z80info *z80, void *intercept_ctx,
+		void (*intercept)(void *, struct z80info *));
+boolean z80_run(z80info *z80, int count);
+void z80_destroy(z80info *z80);
+
+#endif /* __Z80_H_ */

--- a/z80.h
+++ b/z80.h
@@ -82,15 +82,6 @@ typedef struct z80info
     word *regixy[2];
     byte *regir[2];
 
-    /* TODO: These belong to the BIOS state */
-    /* these are for the CP/M BIOS */
-    int	drive;
-    word dma;
-    word track;
-    word sector;
-    FILE *drives[MAXDISCS];
-    long drivelen[MAXDISCS];
-
     /* Private: CPU Interceptor is invoked on each and every loop */
     void *intercept_ctx;
     void (*intercept)(void *, struct z80info *);


### PR DESCRIPTION
These are a few steps towards modularising the emulator and decoupling the key components, namely: `z80`, `bdos`, `bios`, `vm` (virtual machine) and subsequently peripherals, terminal emulators, generalised hooks, etc. I made them backward-compatible.

I have encapsulated most of the states into the respective classes. `vm` will be shortly separated from main.c. The naming convention is mostly preserved, the class method prefixes along with constructors and destructors have been added.

It is worth spending some time on the initial set of unit tests when the model stabilises.

*The CPU fails ZEXALL.* There are more compliant implementations out there. It appears to be easier to replace it than incrementally fixing it. I could write a new one, but that might take a little bit longer.

It has the remaining dependencies on **vm** class:
````
vm_read_mem
vm_write_mem
vm_haltcpu
vm_input
vm_output
vm_undefinstr
````
We can have a single pure virtual class (well, a table of of function pointers for those hooks) or hide them and provide binding methods, e.g. `z80_set_memory_man`, `z80_set_io`, `z80_set_inst_brk`.

Functionally, bdos needs some work and tidying up, but most of the hard work has been done. (The proposed change set contains an intermittent fix of BDOS 33 resulting in an endless loop in `GEN80` with the files sizes == 128 bytes)

*I fully understand that these changes might come across as too radical and deviate from your vision on how the emulator should evolve, but if you are interested, please let me know.*